### PR TITLE
Confirm 2 games & add 1 game

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ List of GAME ID's in Uplay by Ubisoft
 104 - Assassin's Creed® III (JPN)  
 105 -  Assassin's Creed® III (CZ)  
 273 - Assassin’s Creed® IV Black Flag™  
+437 - Assassin’s Creed® IV Black Flag™ (Steam Version) 
 441 - Assassin’s Creed® IV Black Flag™ (RU)  
 442 - Assassin’s Creed® IV Black Flag™ (Asia)  
 625 - Assassin's Creed® Liberation HD  
@@ -20,6 +21,7 @@ List of GAME ID's in Uplay by Ubisoft
 895 - Assassin's Creed Rogue  
 944 - Assassin's Creed Unity (RU)  
 1186 - Assassin's Creed Rogue (RU)  
+1187 - Assassin's Creed Rogue (RU) (Steam Version)
 1651 - Assassin's Creed® Chronicles China  
 1847 - Assassin's Creed® Chronicles India  
 1848 - Assassin's Creed® Chronicles Russia  
@@ -28,6 +30,7 @@ List of GAME ID's in Uplay by Ubisoft
 3539 - Assassin's Creed Origins  
 5059 - Assassin's Creed Odyssey  
 5183 - Assassin's Creed® III Remastered  
+5184 - Assassin's Creed® III Remastered (Steam Version)
 13504 - Assassin's Creed® Valhalla
 
 # FAR CRY Franchise
@@ -106,14 +109,12 @@ List of GAME ID's in Uplay by Ubisoft
 
 # To be verified
 276 - Prince of Persia  
-437 - Assassin’s Creed® IV Black Flag™ (Steam Version)  
 632 - Assassin's Creed® Liberation HD (RU) ?  
 856 - Far Cry® 4 (unknown Version)  
 934 - Assassin's Creed Rogue (unknown Version)  
 1428 - Watch Dogs (US) ?  
 2029 - Far Cry® Primal (RU) ?  
 2052 - Anno 2205 (unknown Version)  
-5184 - Assassin's Creed® III Remastered (RU) ?  
 11957 - Hyper Scape  
 
 More: https://github.com/d3adm4u5/UplayGameIDs/blob/master/latest.txt


### PR DESCRIPTION
1. I can verify that 437 is Assassin's Creed IV Black Flag (Steam version). I have both Uplay and Steam versions and you can find multiple threads related to activating DLCs that mention the difference between 273 and 437 (TLDR: only buy DLC in the same store you've bought the main game).
2. I can verify that 5184 is Assassin's Creed® III Remastered (Steam Version). I cannot confirm that it's a Russian-specific version -- I'm in RU region, but there is nothing locale-specific in my copy of the game (no region/locale lock, no mentions that this version is RU/CIS-only on Steam page, and if I try to buy the game to gift it, it doesn't tell me that I'm restricted to RU/CIS).
3. I have added 1187 as Assassin's Creed Rogue (RU) (Steam Version). I also have 895 (standard Assassin's Creed Rogue in Uplay), and the "A C C [ - 1 ]" signature is present in both cases.

I can provide save games for all these games, if you need them for confirmation/verification.