### PR TITLE
add Assassin's Creed® Black Flag Resynced (Ubisoft Connect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ List of GAME ID's in Uplay by Ubisoft
 11373 - Discovery Tour: Ancient Egypt by Assassin’s Creed (Steam)  
 13504 - Assassin's Creed® Valhalla  
 19000 - Discovery Tour: Viking Age by Ubisoft  
+65043 - Assassin's Creed® Black Flag Resynced
 
 # FAR CRY Franchise
 46 - Far Cry® 3  


### PR DESCRIPTION
This adds the product ID for the Ubisoft Connect (not Steam) version of Assassin's Creed® Black Flag Resynced.

I've confirmed on my own PC that the game can be launched directly using `UbisoftConnect.exe uplay://launch/65043`.